### PR TITLE
Upgrade eslint and inherit from airbnb

### DIFF
--- a/base.js
+++ b/base.js
@@ -1,41 +1,18 @@
 module.exports = {
-  extends: 'eslint:recommended',
+  extends: 'airbnb-base',
   parser: 'babel-eslint',
   env: {
-    es6: true
+    es6: true,
   },
   parserOptions: {
-    ecmaVersion: 6
+    ecmaVersion: 6,
   },
 
   rules: {
-    // Possible Errors
-    // The following rules point out areas where you might have made mistakes.
-
-    // disallow unnecessary parentheses
-    'no-extra-parens': ['error', 'functions'],
-    // disallow use of Object.prototypes builtins directly
-    'no-prototype-builtins': 'error',
-    // Disallow template literal placeholder syntax in regular strings
-    // http://eslint.org/docs/rules/no-template-curly-in-string
-    'no-template-curly-in-string': 'error',
-    // disallow return/throw/break/continue inside finally blocks
-    'no-unsafe-finally': 'error',
-    // Ensure JSDoc comments are valid
-    'valid-jsdoc': 'off',
-
     // Best Practices
     // These are rules designed to prevent you from making mistakes. They either prescribe a better
     // way of doing something or help you avoid footguns.
 
-    // enforces getter/setter pairs in objects
-    'accessor-pairs': 'off',
-    // enforce return statements in callbacks of array's methods
-    'array-callback-return': 'error',
-    // treat var statements as if they were block scoped
-    'block-scoped-var': 'error',
-    // specify the maximum cyclomatic complexity allowed in a program
-    complexity: 'off',
     // enforce that class methods use "this"
     // http://eslint.org/docs/rules/class-methods-use-this
     'class-methods-use-this': ['off', {
@@ -43,83 +20,26 @@ module.exports = {
     }],
     // require return statements to either always or never specify values
     'consistent-return': 'off',
-    // specify curly brace conventions for all control statements
-    curly: 'error',
-    // require default case in switch statements
-    'default-case': 'error',
     // enforces consistent newlines before or after dots
     'dot-location': 'off',
-    // encourages use of dot notation whenever possible
-    'dot-notation': 'error',
-    // require the use of === and !==
-    eqeqeq: 'error',
     // make sure for-in loops have an if statement
     'guard-for-in': 'off',
     // disallow the use of alert, confirm, and prompt
     'no-alert': 'error',
-    // disallow use of arguments.caller or arguments.callee
-    'no-caller': 'error',
-    // disallow division operators explicitly at beginning of regular expression
-    'no-div-regex': 'error',
     // disallow else after a return in an if
     'no-else-return': 'off',
     // disallow use of empty functions
     'no-empty-function': 'off',
-    // disallow comparisons to null without a type-checking operator
-    'no-eq-null': 'error',
-    // disallow use of eval()
-    'no-eval': 'error',
-    // disallow adding to native types
-    'no-extend-native': 'error',
-    // disallow unnecessary function binding
-    'no-extra-bind': 'error',
-    // disallow unnecessary labels
-    'no-extra-label': 'error',
-    // disallow the use of leading or trailing decimal points in numeric literals
-    'no-floating-decimal': 'error',
-    // disallow reassignments of native objects or read-only globals
-    // http://eslint.org/docs/rules/no-global-assign
-    'no-global-assign': ['error', { exceptions: [] }],
-    // disallow the type conversions with shorter notations
-    'no-implicit-coercion': 'off',
-    // disallow var and named functions in global scope
-    'no-implicit-globals': 'error',
-    // disallow use of eval()-like methods
-    'no-implied-eval': 'error',
-    // disallow this keywords outside of classes or class-like objects
-    'no-invalid-this': 'off',
-    // disallow usage of __iterator__ property
-    'no-iterator': 'error',
-    // disallow use of labeled statements
-    'no-labels': 'error',
-    // disallow unnecessary nested blocks
-    'no-lone-blocks': 'error',
-    // disallow creation of functions within loops
-    'no-loop-func': 'error',
-    // disallow the use of magic numbers
-    'no-magic-numbers': 'off',
     // disallow use of multiple spaces
     'no-multi-spaces': 'off',
-    // disallow use of multiline strings
-    'no-multi-str': 'error',
-    // disallow use of new operator when not part of the assignment or comparison
-    'no-new': 'error',
-    // disallow use of new operator for Function object
-    'no-new-func': 'error',
-    // disallows creating new instances of String,Number, and Boolean
-    'no-new-wrappers': 'error',
-    // disallow use of octal escape sequences in string literals, such as var foo = 'Copyright \251';
-    'no-octal-escape': 'error',
     // disallow reassignment of function parameters
     'no-param-reassign': 'off',
-    // disallow usage of __proto__ property
-    'no-proto': 'error',
     // disallow certain object properties
     // http://eslint.org/docs/rules/no-restricted-properties
     'no-restricted-properties': ['error', {
       object: 'arguments',
       property: 'callee',
-      message: 'arguments.callee is deprecated,'
+      message: 'arguments.callee is deprecated,',
     }, {
       property: '__defineGetter__',
       message: 'Please use Object.defineProperty instead.',
@@ -129,178 +49,39 @@ module.exports = {
     }],
     // disallow use of assignment in return statement
     'no-return-assign': 'off',
-    // disallow redundant `return await`
-    'no-return-await': 'error',
     // disallow use of javascript: urls.
     'no-script-url': 'off',
-    // disallow self assignment
-    // http://eslint.org/docs/rules/no-self-assign
-    'no-self-assign': 'error',
-    // disallow comparisons where both sides are exactly the same
-    'no-self-compare': 'error',
-    // disallow use of comma operator
-    'no-sequences': 'error',
-    // restrict what can be thrown as an exception
-    'no-throw-literal': 'error',
-    // disallow unmodified conditions of loops
-    'no-unmodified-loop-condition': 'error',
     // disallow usage of expressions in statement position
     'no-unused-expressions': 'off',
-    // disallow unnecessary .call() and .apply()
-    'no-useless-call': 'off',
-    // disallow unnecessary concatenation of literals or template literals
-    'no-useless-concat': 'error',
-    // disallow unnecessary string escaping
-    'no-useless-escape': 'error',
-    // disallow redundant return; keywords
-    // http://eslint.org/docs/rules/no-useless-return
-    'no-useless-return': 'error',
-    // disallow use of void operator
-    'no-void': 'error',
-    // disallow usage of configurable warning terms in comments - e.g. TODO or FIXME
-    'no-warning-comments': 'off',
-    // disallow use of the with statement
-    'no-with': 'error',
-    // require use of the second argument for parseInt()
-    radix: 'error',
-    // require `await` in `async function`
-    // http://eslint.org/docs/rules/require-await
-    'require-await': 'off',
     // requires to declare all vars on top of their containing scope, covered by let/const
     'vars-on-top': 'off',
     // require immediate function invocation to be wrapped in parentheses
     // http://eslint.org/docs/rules/wrap-iife.html
     'wrap-iife': ['error', 'inside', { functionPrototypeMethods: false }],
-    // require or disallow Yoda conditions
-    yoda: 'error',
-
-    // Strict Mode
-    // These rules relate to using strict mode.
-
-    // require or disallow the 'use strict' pragma in the global scope (off by default in the node environment)
-    strict: ['error', 'never'],
-
-    // Variables
-    // These rules have to do with variable declarations.
-
-    // enforce or disallow variable initializations at definition
-    'init-declarations': 'off',
-    // disallow the catch clause parameter name being the same as a variable in the outer scope
-    // (off by default in the node environment)
-    'no-catch-shadow': 'off',
-    // disallow labels that share a name with a variable
-    'no-label-var': 'error',
-    // restrict usage of specified global variables
-    'no-restricted-globals': 'error',
-    // disallow declaration of variables already declared in the outer scope
-    'no-shadow': 'error',
-    // disallow shadowing of names such as arguments
-    'no-shadow-restricted-names': 'error',
-    // disallow use of undefined when initializing variables
-    'no-undef-init': 'error',
-    // disallow use of undefined variable
-    'no-undefined': 'off',
-    // disallow use of variables before they are defined
-    'no-use-before-define': 'error',
 
     // Node.js
     // These rules are specific to JavaScript running on Node.js.
 
-    // enforce return after a callback
-    'callback-return': 'off',
-    // enforces error handling in callbacks (on by default in the node environment)
-    'handle-callback-err': 'off',
-    // disallow mixing regular variable and require declarations (on by default in the node environment)
-    'no-mixed-requires': 'off',
     // disallow use of new operator with the require function (on by default in the node environment)
     'no-new-require': 'off',
     // disallow string concatenation with __dirname and __filename (on by default in the node environment)
     'no-path-concat': 'off',
-    // disallow process.exit() (on by default in the node environment)
-    'no-process-exit': 'off',
-    // restrict usage of specified node modules
-    'no-restricted-modules': 'off',
-    // disallow use of synchronous methods
-    'no-sync': 'off',
 
     // Stylistic Issues
     // These rules are purely matters of style and are quite subjective.
 
     // enforce spacing inside array brackets
     'array-bracket-spacing': ['off', 'never'],
-    // disallow or enforce spaces inside of single line blocks
-    'block-spacing': 'error',
-    // enforce one true brace style
-    'brace-style': ['error', '1tbs', { allowSingleLine: true }],
-    // require camel case names
-    camelcase: ['error', { properties: 'never' }],
-    // enforce or disallow capitalization of the first letter of a comment
-    // http://eslint.org/docs/rules/capitalized-comments
-    'capitalized-comments': ['off', 'never', {
-      line: {
-        ignorePattern: '.*',
-        ignoreInlineComments: true,
-        ignoreConsecutiveComments: true,
-      },
-      block: {
-        ignorePattern: '.*',
-        ignoreInlineComments: true,
-        ignoreConsecutiveComments: true,
-      },
-    }],
-    // enforce spacing before and after comma
-    'comma-spacing': ['error', { before: false, after: true }],
-    // enforce one true comma style
-    'comma-style': ['error', 'last'],
-    // disallow padding inside computed properties
-    'computed-property-spacing': ['error', 'never'],
-    // enforces consistent naming when capturing the current execution context
-    'consistent-this': 'off',
-    // enforce newline at the end of file, with no multiple empty lines
-    'eol-last': 'error',
-    // enforce spacing between functions and their invocations
-    // http://eslint.org/docs/rules/func-call-spacing
-    'func-call-spacing': ['error', 'never'],
-    // requires function names to match the name of the variable or property to which they are
-    // assigned
-    // http://eslint.org/docs/rules/func-name-matching
-    'func-name-matching': ['off', { includeCommonJSModuleExports: false }],
+    // require trailing commas in multiline object literals
+    'comma-dangle': 'off',
     // require function expressions to have a name
     'func-names': 'off',
-    // enforces use of function declarations or expressions
-    'func-style': 'off',
-    // blacklist certain identifiers to prevent them being used
-    'id-blacklist': 'off',
-    // enforces minimum and maximum identifier lengths (variable names, property names etc.)
-    'id-length': 'off',
-    // require identifiers to match the provided regular expression
-    'id-match': 'off',
     // specify tab or space width for your code
     indent: ['error', 2],
     // enforce spacing between keys and values in object literal properties
     'key-spacing': 'off',
     // enforce spacing before and after keywords
     'keyword-spacing': 'error',
-    // enforce position of line comments
-    // http://eslint.org/docs/rules/line-comment-position
-    // TODO: enable?
-    'line-comment-position': ['off', {
-      position: 'above',
-      ignorePattern: '',
-      applyDefaultPatterns: true,
-    }],
-    // disallow mixed 'LF' and 'CRLF' as linebreaks
-    'linebreak-style': ['error', 'unix'],
-    // enforces empty lines around comments
-    'lines-around-comment': 'off',
-    // require or disallow newlines around directives
-    // http://eslint.org/docs/rules/lines-around-directive
-    'lines-around-directive': ['error', {
-      before: 'always',
-      after: 'always',
-    }],
-    // specify the maximum depth that blocks can be nested
-    'max-depth': ['off', 5],
     // specify the maximum length of a line in your program
     // http://eslint.org/docs/rules/max-len
     'max-len': ['error', 120, 2, {
@@ -310,204 +91,103 @@ module.exports = {
       ignoreStrings: true,
       ignoreTemplateLiterals: true,
     }],
-    // specify the maximum depth callbacks can be nested
-    'max-nested-callbacks': 'off',
-    // specify the number of parameters that can be used in the function declaration
-    'max-params': 'off',
-    // specify the maximum number of statement allowed in a function
-    'max-statements': 'off',
-    // specify the maximum number of statements allowed per line
-    'max-statements-per-line': 'off',
-
-    // require multiline ternary
-    // http://eslint.org/docs/rules/multiline-ternary
-    // TODO: enable?
-    'multiline-ternary': ['off', 'never'],
-
     // require a capital letter for constructors
     'new-cap': ['error', {
       newIsCap: true,
-      capIsNewExceptions: []
+      capIsNewExceptions: [],
     }],
-    // disallow the omission of parentheses when invoking a constructor with no arguments
-    'new-parens': 'error',
-    // allow/disallow an empty newline after var statement
-    'newline-after-var': 'off',
-    // require newline before return statement
-    'newline-before-return': 'off',
     // enforce newline after each call when chaining the calls
     'newline-per-chained-call': 'off',
-    // disallow use of the Array constructor
-    'no-array-constructor': 'error',
     // disallow use of bitwise operators
     'no-bitwise': 'off',
     // disallow use of the continue statement
     'no-continue': 'off',
-    // disallow comments inline after code
-    'no-inline-comments': 'off',
-    // disallow if as the only statement in an else block
-    // http://eslint.org/docs/rules/no-lonely-if
-    'no-lonely-if': 'error',
-    // disallow un-paren'd mixes of different operators
-    'no-mixed-operators': ['error', {
-      groups: [
-        ['+', '-', '*', '/', '%', '**'],
-        ['&', '|', '^', '~', '<<', '>>', '>>>'],
-        ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
-        ['&&', '||'],
-        ['in', 'instanceof']
-      ],
-      allowSamePrecedence: false
-    }],
+    // disallow use of chained assignment expressions
+    // http://eslint.org/docs/rules/no-multi-assign
+    'no-multi-assign': ['off'],
     // disallow multiple empty lines
     'no-multiple-empty-lines': 'off',
-    // disallow negated conditions
-    'no-negated-condition': 'off',
     // disallow nested ternary expressions
     'no-nested-ternary': 'off',
-    // disallow use of the Object constructor
-    'no-new-object': 'error',
     // disallow use of unary operators, ++ and --
     'no-plusplus': 'off',
     // disallow use of certain syntax in code
     'no-restricted-syntax': 'off',
-    // disallow tab characters entirely
-    'no-tabs': 'error',
-    // disallow the use of ternary operators
-    'no-ternary': 'off',
-    // disallow trailing whitespace at the end of lines
-    'no-trailing-spaces': 'error',
     // disallow dangling underscores in identifiers
     'no-underscore-dangle': 'off',
-    // disallow the use of Boolean literals in conditional expressions
-    // also, prefer `a || b` over `a ? a : b`
-    'no-unneeded-ternary': ['error', { defaultAssignment: false }],
-    // disallow whitespace before properties
-    'no-whitespace-before-property': 'error',
     // require padding inside curly braces
     'object-curly-spacing': ['off', 'always'],
-    // enforce line breaks between braces
-    // TODO: enable once https://github.com/eslint/eslint/issues/6488 is resolved
-    'object-curly-newline': ['off', {
-      ObjectExpression: { minProperties: 0, multiline: true },
-      ObjectPattern: { minProperties: 0, multiline: true }
-    }],
     // enforce "same line" or "multiple line" on object properties.
     'object-property-newline': ['off', {
       allowMultiplePropertiesPerLine: true
     }],
-    // allow just one var statement per function
-    'one-var': ['error', 'never'],
-    // require a newline around variable declaration
-    'one-var-declaration-per-line': ['error', 'always'],
-    // require assignment operator shorthand where possible or prohibit it entirely
-    // http://eslint.org/docs/rules/operator-assignment
-    'operator-assignment': ['error', 'always'],
-    // enforce operators to be placed before or after line breaks
-    'operator-linebreak': 'off',
-    // enforce padding within blocks
-    'padded-blocks': ['error', 'never'],
-    // require quotes around object literal property names
-    // http://eslint.org/docs/rules/quote-props.html
-    'quote-props': ['error', 'as-needed', { keywords: false, unnecessary: true, numbers: false }],
-    // specify whether double or single quotes should be used
-    quotes: ['error', 'single', 'avoid-escape'],
-    // Require JSDoc comment
-    'require-jsdoc': 'off',
-    // require or disallow use of semicolons instead of ASI
-    semi: ['error', 'always'],
-    // disallow space before semicolon
-    'semi-spacing': ['error', {before: false, after: true}],
-    // requires object keys to be sorted
-    'sort-keys': ['off', 'asc', { caseSensitive: false, natural: true }],
-    // sort variables within the same declaration block
-    'sort-vars': 'off',
-    // require or disallow a space before blocks
-    'space-before-blocks': 'error',
     // require or disallow space before function opening parenthesis
     // http://eslint.org/docs/rules/space-before-function-paren
     'space-before-function-paren': ['error', {
       anonymous: 'never',
       named: 'never',
-      asyncArrow: 'always'
+      asyncArrow: 'always',
     }],
-    // require or disallow spaces inside parentheses
-    'space-in-parens': ['error', 'never'],
-    // require spaces around operators
-    'space-infix-ops': 'error',
     // require a space around word operators such as typeof
     'space-unary-ops': 'error',
     // require or disallow a space immediately following the // or /* in a comment
     'spaced-comment': 'off',
-    // require regex literals to be wrapped in parentheses
-    'wrap-regex': 'off',
 
     // ECMAScript 6
     // These rules are only relevant to ES6 environments.
 
-    // enforces no braces where they can be omitted
-    // http://eslint.org/docs/rules/arrow-body-style
-    'arrow-body-style': ['error', 'as-needed', {
-      requireReturnForObjectLiteral: false,
-    }],
     // require parens in arrow function arguments
     'arrow-parens': 'off',
     // require space before/after arrow function's arrow
     'arrow-spacing': 'error',
     // enforce the spacing around the * in generator functions
     'generator-star-spacing': 'off',
-    // disallow arrow functions where they could be confused with comparisons
-    // http://eslint.org/docs/rules/no-confusing-arrow
-    'no-confusing-arrow': ['error', {
-      allowParens: true,
-    }],
-    // disallow importing from the same path more than once
-    'no-duplicate-imports': 'error',
-    // restrict usage of specified node imports
-    'no-restricted-imports': 'off',
-    // disallow useless computed property keys
-    'no-useless-computed-key': 'error',
-    // disallow unnecessary constructor
-    'no-useless-constructor': 'error',
     // disallow renaming import, export, and destructured assignments to the same name
     'no-useless-rename': ['off', {
       ignoreDestructuring: false,
       ignoreImport: false,
-      ignoreExport: false
+      ignoreExport: false,
     }],
-    'no-var': 'error',
     'object-shorthand': 'off',
     // suggest using arrow functions as callbacks
     'prefer-arrow-callback': 'off',
-    // suggest using of const declaration for variables that are never modified after declared
-    'prefer-const': ['error', {
-      destructuring: 'any',
-      ignoreReadBeforeAssign: true,
-    }],
-    // disallow parseInt() in favor of binary, octal, and hexadecimal literals
-    // http://eslint.org/docs/rules/prefer-numeric-literals
-    'prefer-numeric-literals': 'error',
-    // suggest using Reflect methods where applicable
-    'prefer-reflect': 'off',
-    // suggest using the rest parameters instead of arguments
-    'prefer-rest-params': 'error',
-    // suggest using the spread operator instead of .apply()
-    // http://eslint.org/docs/rules/prefer-spread
-    'prefer-spread': 'error',
-    // suggest using template literals instead of strings concatenation
-    'prefer-template': 'error',
     // disallow generator functions that do not have yield
     'require-yield': 'off',
-    // enforce spacing between object rest-spread
-    'rest-spread-spacing': ['error', 'never'],
-    // sort import declarations within module
-    'sort-imports': 'off',
-    // require a Symbol description
-    // http://eslint.org/docs/rules/symbol-description
-    'symbol-description': 'error',
     // enforce spacing around embedded expressions of template strings
     'template-curly-spacing': 'off',
     // enforce spacing around the * in yield* expressions
-    'yield-star-spacing': 'off'
-  }
+    'yield-star-spacing': 'off',
+
+    // Imports
+    // TODO: Turn these on
+    'import/extensions': ['error', 'always', {
+      js: 'never',
+      jsx: 'never',
+      coffee: 'never',
+      cjsx: 'never'
+    }],
+    'import/first': ['off', 'absolute-first'],
+    // Require a newline after the last import/require in a group
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/newline-after-import.md
+    'import/newline-after-import': 'off',
+    // Require modules with a single export to use a default export
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md
+    'import/prefer-default-export': 'off',
+    // Forbid Webpack loader syntax in imports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md
+    'import/no-webpack-loader-syntax': 'off',
+    // do not allow a default import name to match a named export
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default.md
+    'import/no-named-as-default': 'off',
+    'import/no-extraneous-dependencies': ['error', {
+      devDependencies: [
+        'spec/**', // mocha, rspec-like pattern
+        'frontend/javascripts/spec/**', // mocha, rspec-like pattern
+        '**/*_spec.js*', // tests where the extension denotes that it is a test
+        '**/webpack.config.js', // webpack config
+      ],
+      optionalDependencies: false,
+    }],
+    'import/no-named-as-default-member': 'off',
+  },
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: [
     './base',
-    './react'
+    './react',
   ].map(require.resolve),
-  rules: {}
+  rules: {},
 };

--- a/package.json
+++ b/package.json
@@ -14,11 +14,16 @@
     "lint": "eslint ."
   },
   "devDependencies": {
-    "babel-eslint": "^7.1.1",
-    "eslint": "^3.11.1"
+    "babel-eslint": "^7.2.2",
+    "eslint": "3.19.0",
+    "eslint-plugin-import": "2.2.0"
   },
   "peerDependencies": {
-    "babel-eslint": "^7.1",
-    "eslint": "^3.11"
+    "babel-eslint": "^7.2",
+    "eslint": "^3.19.0",
+    "eslint-plugin-import": "^2.2.0"
+  },
+  "dependencies": {
+    "eslint-config-airbnb-base": "^11.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/eslint-config-gusto",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "Gusto shared ESLint config",
   "main": "index.js",
   "author": "Rylan Collins <rylan@gusto.com>",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,9 +12,9 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.3.tgz#1a3e850b428e73ba6b09d1cc527f5aaad4d03ef1"
+acorn@^5.0.1:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
 
 ajv-keywords@^1.0.0:
   version "1.2.0"
@@ -59,63 +59,62 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-babel-code-frame@^6.16.0, babel-code-frame@^6.20.0:
-  version "6.20.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.20.0.tgz#b968f839090f9a8bc6d41938fb96cb84f7387b26"
+babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
     chalk "^1.1.0"
     esutils "^2.0.2"
-    js-tokens "^2.0.0"
+    js-tokens "^3.0.0"
 
-babel-eslint@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.1.1.tgz#8a6a884f085aa7060af69cfc77341c2f99370fb2"
+babel-eslint@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.2.tgz#0da2cbe6554fd0fb069f19674f2db2f9c59270ff"
   dependencies:
-    babel-code-frame "^6.16.0"
-    babel-traverse "^6.15.0"
-    babel-types "^6.15.0"
-    babylon "^6.13.0"
-    lodash.pickby "^4.6.0"
+    babel-code-frame "^6.22.0"
+    babel-traverse "^6.23.1"
+    babel-types "^6.23.0"
+    babylon "^6.16.1"
 
-babel-messages@^6.8.0:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.8.0.tgz#bf504736ca967e6d65ef0adb5a2a5f947c8e0eb9"
+babel-messages@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
   dependencies:
-    babel-runtime "^6.0.0"
+    babel-runtime "^6.22.0"
 
-babel-runtime@^6.0.0, babel-runtime@^6.20.0:
-  version "6.20.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.20.0.tgz#87300bdcf4cd770f09bf0048c64204e17806d16f"
+babel-runtime@^6.22.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-traverse@^6.15.0:
-  version "6.20.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.20.0.tgz#5378d1a743e3d856e6a52289994100bbdfd9872a"
+babel-traverse@^6.23.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
   dependencies:
-    babel-code-frame "^6.20.0"
-    babel-messages "^6.8.0"
-    babel-runtime "^6.20.0"
-    babel-types "^6.20.0"
-    babylon "^6.11.0"
+    babel-code-frame "^6.22.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+    babylon "^6.15.0"
     debug "^2.2.0"
     globals "^9.0.0"
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.15.0, babel-types@^6.20.0:
-  version "6.20.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.20.0.tgz#3869ecb98459533b37df809886b3f7f3b08d2baa"
+babel-types@^6.23.0, babel-types@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
   dependencies:
-    babel-runtime "^6.20.0"
+    babel-runtime "^6.22.0"
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.11.0, babylon@^6.13.0:
-  version "6.14.1"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.14.1.tgz#956275fab72753ad9b3435d7afe58f8bf0a29815"
+babylon@^6.15.0, babylon@^6.16.1:
+  version "6.16.1"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
 
 balanced-match@^0.4.1:
   version "0.4.2"
@@ -127,6 +126,14 @@ brace-expansion@^1.0.0:
   dependencies:
     balanced-match "^0.4.1"
     concat-map "0.0.1"
+
+buffer-shims@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
+
+builtin-modules@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -174,13 +181,17 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.6:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.5.2.tgz#708978624d856af41a5a741defdd261da752c266"
+concat-stream@^1.5.2:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
-    inherits "~2.0.1"
-    readable-stream "~2.0.0"
-    typedarray "~0.0.5"
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
 core-js@^2.4.0:
   version "2.4.1"
@@ -195,6 +206,12 @@ d@^0.1.1, d@~0.1.1:
   resolved "https://registry.yarnpkg.com/d/-/d-0.1.1.tgz#da184c535d18d8ee7ba2aa229b914009fae11309"
   dependencies:
     es5-ext "~0.10.2"
+
+debug@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
+  dependencies:
+    ms "0.7.1"
 
 debug@^2.1.1, debug@^2.2.0:
   version "2.3.3"
@@ -218,9 +235,16 @@ del@^2.0.2:
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
 
-doctrine@^1.2.2:
+doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
+doctrine@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
@@ -290,22 +314,57 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^3.11.1:
-  version "3.11.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.11.1.tgz#408be581041385cba947cd8d1cd2227782b55dbf"
+eslint-config-airbnb-base@^11.1.3:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.1.3.tgz#0e8db71514fa36b977fbcf977c01edcf863e0cf0"
+
+eslint-import-resolver-node@^0.2.0:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz#5add8106e8c928db2cba232bcd9efa846e3da16c"
+  dependencies:
+    debug "^2.2.0"
+    object-assign "^4.0.1"
+    resolve "^1.1.6"
+
+eslint-module-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz#a6f8c21d901358759cdc35dbac1982ae1ee58bce"
+  dependencies:
+    debug "2.2.0"
+    pkg-dir "^1.0.0"
+
+eslint-plugin-import@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz#72ba306fad305d67c4816348a4699a4229ac8b4e"
+  dependencies:
+    builtin-modules "^1.1.1"
+    contains-path "^0.1.0"
+    debug "^2.2.0"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.2.0"
+    eslint-module-utils "^2.0.0"
+    has "^1.0.1"
+    lodash.cond "^4.3.0"
+    minimatch "^3.0.3"
+    pkg-up "^1.0.0"
+
+eslint@3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
   dependencies:
     babel-code-frame "^6.16.0"
     chalk "^1.1.3"
-    concat-stream "^1.4.6"
+    concat-stream "^1.5.2"
     debug "^2.1.1"
-    doctrine "^1.2.2"
+    doctrine "^2.0.0"
     escope "^3.6.0"
-    espree "^3.3.1"
+    espree "^3.4.0"
+    esquery "^1.0.0"
     estraverse "^4.2.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
     glob "^7.0.3"
-    globals "^9.2.0"
+    globals "^9.14.0"
     ignore "^3.2.0"
     imurmurhash "^0.1.4"
     inquirer "^0.12.0"
@@ -324,21 +383,27 @@ eslint@^3.11.1:
     require-uncached "^1.0.2"
     shelljs "^0.7.5"
     strip-bom "^3.0.0"
-    strip-json-comments "~1.0.1"
+    strip-json-comments "~2.0.1"
     table "^3.7.8"
     text-table "~0.2.0"
     user-home "^2.0.0"
 
-espree@^3.3.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.3.2.tgz#dbf3fadeb4ecb4d4778303e50103b3d36c88b89c"
+espree@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.1.tgz#28a83ab4aaed71ed8fe0f5efe61b76a05c13c4d2"
   dependencies:
-    acorn "^4.0.1"
+    acorn "^5.0.1"
     acorn-jsx "^3.0.0"
 
 esprima@^2.6.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+
+esquery@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+  dependencies:
+    estraverse "^4.0.0"
 
 esrecurse@^4.1.0:
   version "4.1.0"
@@ -347,7 +412,7 @@ esrecurse@^4.1.0:
     estraverse "~4.1.0"
     object-assign "^4.0.1"
 
-estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.0.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -388,6 +453,13 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
+find-up@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
+  dependencies:
+    path-exists "^2.0.0"
+    pinkie-promise "^2.0.0"
+
 flat-cache@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.2.1.tgz#6c837d6225a7de5659323740b36d5361f71691ff"
@@ -400,6 +472,10 @@ flat-cache@^1.2.1:
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+function-bind@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
 generate-function@^2.0.0:
   version "2.0.0"
@@ -422,9 +498,9 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.0.0, globals@^9.2.0:
-  version "9.14.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.14.0.tgz#8859936af0038741263053b39d0e76ca241e4034"
+globals@^9.0.0, globals@^9.14.0:
+  version "9.17.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -447,6 +523,12 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
+  dependencies:
+    function-bind "^1.0.2"
+
 ignore@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.0.tgz#8d88f03c3002a0ac52114db25d2c673b0bf1e435"
@@ -462,7 +544,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@~2.0.1:
+inherits@2, inherits@^2.0.3, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -547,6 +629,10 @@ js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
 
+js-tokens@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
+
 js-yaml@^3.5.1:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
@@ -575,9 +661,9 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lodash.pickby@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
+lodash.cond@^4.3.0:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
 lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.2"
@@ -589,7 +675,7 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^2.0.0"
 
-minimatch@^3.0.2:
+minimatch@^3.0.2, minimatch@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
@@ -604,6 +690,10 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+ms@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
 ms@0.7.2:
   version "0.7.2"
@@ -650,6 +740,12 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
+path-exists@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
+  dependencies:
+    pinkie-promise "^2.0.0"
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -672,6 +768,18 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  dependencies:
+    find-up "^1.0.0"
+
+pkg-up@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-1.0.0.tgz#3e08fb461525c4421624a33b9f7e6d0af5b05a26"
+  dependencies:
+    find-up "^1.0.0"
+
 pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
@@ -688,15 +796,16 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
-readable-stream@~2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
+readable-stream@^2.2.2:
+  version "2.2.9"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.9.tgz#cf78ec6f4a6d1eb43d26488cac97f042e74b7fc8"
   dependencies:
+    buffer-shims "~1.0.0"
     core-util-is "~1.0.0"
     inherits "~2.0.1"
     isarray "~1.0.0"
     process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
+    string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
 
 readline2@^1.0.1:
@@ -786,9 +895,11 @@ string-width@^2.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^3.0.0"
 
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+string_decoder@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.0.tgz#f06f41157b664d86069f84bdbdc9b0d8ab281667"
+  dependencies:
+    buffer-shims "~1.0.0"
 
 strip-ansi@^3.0.0:
   version "3.0.1"
@@ -800,9 +911,9 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
-strip-json-comments@~1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -841,7 +952,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typedarray@~0.0.5:
+typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 


### PR DESCRIPTION
The results of this are minor.  I upgraded eslint and started inheriting from airbnb's config so we can slowly remove the rules we define. I override the current differences between our config and theirs. Here's the PR for ZP: https://github.com/Gusto/zenpayroll/pull/14560