### PR TITLE
Bump babel-eslint to version 10.0.0 so we are not using a version of babel-eslint with release candidate sub dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-gusto",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "A shared ESLint config for Gusto's JS projects",
   "main": "index.js",
   "author": "Rylan Collins <rylan@gusto.com>",
@@ -16,7 +16,7 @@
   "devDependencies": {},
   "peerDependencies": {},
   "dependencies": {
-    "babel-eslint": "8.2.6",
+    "babel-eslint": "10.0.0",
     "eslint": "5.4.0",
     "eslint-config-airbnb": "17.1.0",
     "eslint-config-prettier": "3.0.1",


### PR DESCRIPTION
The version of babel-eslint we are using has beta versions for sub dependencies: https://github.com/babel/babel-eslint/blob/v8.2.6/package.json

I think this is causing issues with yarn properly reconciling versions for babel types.  See these for more information:
https://jira.gustocorp.com/browse/DEVOPS-2940
https://github.com/Gusto/hawaiian-ice/pull/7488