### PR TITLE
Clean up rules to focus more on value delivery / quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 9.2.0 - 2018-11-12
+
+* Remove `react/destructuring-assignment` rule is it does not help with code quality.
+* Upgraded dependencies:
+  - `eslint`: 5.9.0
+  - `eslint-config-prettier`: 3.3.0
+  - `eslint-plugin-prettier`: 3.0.0
+  - `prettier`: 1.15.2
+
 ## 9.0.0 - 2018-08-24
 
 ### Upgraded

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
         optionalDependencies: false,
       },
     ],
+    'react/destructuring-assignment': false,
   },
 
   settings: {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,6 @@ module.exports = {
     // rule deprecated in favor of jsx-a11y/label-has-associated-control
     'jsx-a11y/label-has-for': false,
     'react/destructuring-assignment': false,
-    'react/sort-comp': false,
   },
 
   settings: {

--- a/index.js
+++ b/index.js
@@ -13,17 +13,6 @@ module.exports = {
         optionalDependencies: false,
       },
     ],
-    // changes default `assert` value from `both` to `either`
-    'jsx-a11y/label-has-associated-control': [
-      'error',
-      {
-        labelComponents: [],
-        labelAttributes: [],
-        controlComponents: [],
-        assert: 'either',
-        depth: 25,
-      },
-    ],
     // rule deprecated in favor of jsx-a11y/label-has-associated-control
     'jsx-a11y/label-has-for': false,
     'react/destructuring-assignment': false,

--- a/index.js
+++ b/index.js
@@ -13,7 +13,21 @@ module.exports = {
         optionalDependencies: false,
       },
     ],
+    // changes default `assert` value from `both` to `either`
+    'jsx-a11y/label-has-associated-control': [
+      'error',
+      {
+        labelComponents: [],
+        labelAttributes: [],
+        controlComponents: [],
+        assert: 'either',
+        depth: 25,
+      },
+    ],
+    // rule deprecated in favor of jsx-a11y/label-has-associated-control
+    'jsx-a11y/label-has-for': false,
     'react/destructuring-assignment': false,
+    'react/sort-comp': false,
   },
 
   settings: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-gusto",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "description": "A shared ESLint config for Gusto's JS projects",
   "main": "index.js",
   "author": "Rylan Collins <rylan@gusto.com>",

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
   "devDependencies": {},
   "peerDependencies": {},
   "dependencies": {
-    "babel-eslint": "10.0.0",
-    "eslint": "5.4.0",
+    "babel-eslint": "10.0.1",
+    "eslint": "5.9.0",
     "eslint-config-airbnb": "17.1.0",
-    "eslint-config-prettier": "3.0.1",
+    "eslint-config-prettier": "3.3.0",
     "eslint-formatter-todo": "1.0.1",
     "eslint-plugin-import": "2.14.0",
-    "eslint-plugin-jsx-a11y": "6.1.1",
-    "eslint-plugin-prettier": "2.6.2",
+    "eslint-plugin-jsx-a11y": "6.1.2",
+    "eslint-plugin-prettier": "3.0.0",
     "eslint-plugin-react": "7.11.1",
-    "prettier": "1.14.2"
+    "prettier": "1.15.2"
   }
 }


### PR DESCRIPTION
I think it makes more sense to updates these rules here than in all the consuming repo. We don't always need to take this approach and relaxing rules in consuming repos could be a good first step until we're sure we want to make it widespread. But these rule seem to me to make sense here.

[react/destructuring-assignment](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/destructuring-assignment.md) is particularly egregious - adding no value and causing hundreds of linter errors.
[react/sort-comp](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md) creates several errors and again offers little-to-no value. I don't think it offers any quality improvements and I'd prefer to not have any purely stylistic rules like this one. The only argument I can see right now is that the added consistency _could_ be seen as a minor developer time-save for scanning files. But as a developer, I find these kinds of rules really annoying and their arguments very weak. In my experience, this tends to turn devs off to linting vs showing them how useful it can be, helping to improve productivity.
[jsx-a11y/html-has-for](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md) and [jsx-a11y/label-has-associated-control](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md) are relaxed to _either_ have `htmlFor` attribute or nested input instead of requiring both (which would have 100% screenreader coverage) since our component library would have >10 errors that would require effort to resolve if we kept the default (`both`) configuration.