### PR TITLE
Update ESLint rule severity values

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ module.exports = {
       },
     ],
     // rule deprecated in favor of jsx-a11y/label-has-associated-control
-    'jsx-a11y/label-has-for': false,
-    'react/destructuring-assignment': false,
+    'jsx-a11y/label-has-for': 'off',
+    'react/destructuring-assignment': 'off',
   },
 
   settings: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-gusto",
-  "version": "9.5.0",
+  "version": "9.5.1",
   "description": "A shared ESLint config for Gusto's JS projects",
   "main": "index.js",
   "author": "Rylan Collins <rylan@gusto.com>",


### PR DESCRIPTION
Updating the ESLint rule severity values to something that ESLint understands.

Stumbled upon this when trying to update `eslint-config-gusto` in HI and got this message:
```
Error: eslint-config-gusto:
--
  | Configuration for rule "react/destructuring-assignment" is invalid:
  | Severity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed 'false').

```
https://buildkite.com/gusto/hawaiian-ice/builds/32781#7c8212de-862a-4340-94ac-01703a274b79

Looking at the ESLint config validator, it appears to only accept the values `0`, `1`, `2` or `off`, `warn`, and `error`: https://github.com/eslint/eslint/blob/master/lib/shared/config-validator.js#L79

I'm a little surprised ZP hasn't stumbled into this because ZP has been using the version with false instead of off for a few months. Let me know if there was something else you configured in ZP! 