### PR TITLE
Jest configuration update

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,14 @@ module.exports = {
     'import/no-extraneous-dependencies': [
       'error',
       {
-        devDependencies: ['**/{spec,test}/**', '**/*_spec.{js,jsx}', '**/webpack.config.js'],
+        devDependencies: [
+          '**/{spec,test}/**',
+          '**/__tests__/**',
+          '**/__mocks__/**',
+          '**/*_spec.{js,jsx,ts,tsx}',
+          '**/*.{spec,test}.{js,jsx,ts,tsx}',
+          '**/webpack.config.js',
+        ],
         optionalDependencies: false,
       },
     ],


### PR DESCRIPTION
This PR is intended to capture Jest's test specifications in terms of file name conventions, where test files are within a `__tests__` folder and/or `.spec`/`.test` file. Also includes `__mocks__` directories for Jest mocks

Changes:
- Added `__tests__` and `__mocks__` directories to config
- Added `.spec.*` and `.test.*` files to config
- Added typescript variants to config