### PR TITLE
feat: update prettier to 1.19.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 9.9.0 - 2019-11-11
+
+- Upgraded dependencies:
+  - `prettier`: 1.18.2. :arrow_up_small: 1.19.1
+    - THIS MAY CAUSE LINT FAILURES - prettier stops breaking template literals
+
 ## 9.8.0 - 2019-09-19
 
 - Upgraded dependencies:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-gusto",
-  "version": "9.8.0",
+  "version": "9.9.0",
   "description": "A shared ESLint config for Gusto's JS projects",
   "main": "index.js",
   "author": "Rylan Collins <rylan@gusto.com>",

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "babel-eslint": "^10.0.3",
     "eslint": "^5.16.0",
     "eslint-config-airbnb": "^17.1.0",
-    "eslint-config-prettier": "^6.3.0",
+    "eslint-config-prettier": "^6.5.0",
     "eslint-formatter-todo": "^1.0.1",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.14.3",
-    "prettier": "~1.18.2"
+    "prettier": "^1.19.1"
   }
 }


### PR DESCRIPTION
This version supports optional chaining and nullish coalescing in JS and TS contexts.

### [prettier changelog for 1.19.0](https://prettier.io/blog/2019/11/09/1.19.0.html)