### PR TITLE
Feat: Resolve extensions ts/tsx by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 9.10.0 - 2019-12-11
+
+- [Feat] minor - Configure the import resolver to include typescript files. This package does not currently handle ts files but consumers may. This configuration makes it so they don't have to override. There shouldn't be any downside for non-ts consumers. "Feature" but should not cause any breaks.
+
 ## 9.9.0 - 2019-11-11
 
 - Upgraded dependencies:

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = {
   settings: {
     'import/resolver': {
       node: {
-        extensions: ['.js', '.jsx'],
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
       },
     },
     react: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-gusto",
-  "version": "9.9.0",
+  "version": "9.10.0",
   "description": "A shared ESLint config for Gusto's JS projects",
   "main": "index.js",
   "author": "Rylan Collins <rylan@gusto.com>",


### PR DESCRIPTION
This shouldn't break anything. It shouldn't have any negative effect on projects not using typescript.

We don't currently have any typescript configurations here in the package because some consumers are not typescript. I'm going to figure out a good way for us to share our configurations without burdening non-ts repos. In the mean time this is a small convenience.