### PR TITLE
Move `eslint` from `dependencies` to `peerDependencies`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 yarn-error.log
 .history
+/.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 12.0.0 - 2020-11-23
+
+- [Breaking] Move `eslint` from `dependencies` to `peerDependencies`
+  - Users of this package must add `eslint` to their `dependencies` if it is not already there. 
+
 ## 11.1.0 - 2020-11-23
 
 - Upgraded dependencies:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ We also include [prettier](https://github.com/prettier/prettier) as a dependency
 yarn add --dev eslint-config-gusto
 ```
 
+also add `eslint` if not already added
+```
+yarn add --dev eslint
+```
+
 Extend the shared eslint config in your `.eslintrc.js`:
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-gusto",
-  "version": "11.1.0",
+  "version": "12.0.0",
   "description": "A shared ESLint config for Gusto's JS projects",
   "main": "index.js",
   "author": "Rylan Collins <rylan@gusto.com>",
@@ -13,11 +13,14 @@
     "test": "npm run lint",
     "lint": "eslint ."
   },
-  "devDependencies": {},
-  "peerDependencies": {},
+  "devDependencies": {
+    "eslint": "^7.14.0"
+  },
+  "peerDependencies": {
+    "eslint": "^7.14.0"
+  },
   "dependencies": {
     "babel-eslint": "^10.1.0",
-    "eslint": "^7.14.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-prettier": "^6.15.0",
     "eslint-formatter-todo": "^1.0.1",


### PR DESCRIPTION
This change mimics `eslint-config-airbnb`'s dependencies. `yarn` prefers it this way too - users will get warnings about missing peer dependency from other eslint config or plugin packages they use if their only inclusion of `eslint` is through this package. Sounds like `yarn@2` is even less happy about this current pattern.