### PR TITLE
fix: update deprecated config jsxBracketSameLine

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -8,7 +8,7 @@ module.exports = {
   singleQuote: true, // default: false
   trailingComma: 'all', // default: 'es5'
   bracketSpacing: true,
-  jsxBracketSameLine: false,
+  bracketSameLine: false,
   arrowParens: 'avoid', // default: 'always'
   rangeStart: 0,
   rangeEnd: Infinity,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## 12.0.1 - 2021-09-11
+
+- Fix: update deprecated configuration option `jsxBracketSameLine` => `bracketSameLine`
+
 ## 12.0.0 - 2020-11-23
 
 - [Breaking] Move `eslint` from `dependencies` to `peerDependencies`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-gusto",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "A shared ESLint config for Gusto's JS projects",
   "main": "index.js",
   "author": "Rylan Collins <rylan@gusto.com>",


### PR DESCRIPTION
eslint says this old version is deprecated and to update to this new version. The following message is being emitted on eslint run.
>jsxBracketSameLine is deprecated.

https://prettier.io/docs/en/options.html#deprecated-jsx-brackets